### PR TITLE
Improve Nessus REST API

### DIFF
--- a/lib/nessus/nessus-xmlrpc.rb
+++ b/lib/nessus/nessus-xmlrpc.rb
@@ -276,5 +276,38 @@ module Nessus
       resp = @connection.request(request)
       return resp.code
     end
+
+    def report_list_hash
+      raise NotImplementedError
+    end
+
+    def scan_list_hash
+      raise NotImplementedError
+    end
+
+    def report_host_ports
+      raise NotImplementedError
+    end
+
+    def scan_new
+      raise NotImplementedError
+    end
+
+    def report_file_download
+      raise NotImplementedError
+    end
+
+    def template_list_hash
+      raise NotImplementedError
+    end
+
+    def report_host
+      raise NotImplementedError
+    end
+
+    def report_host_port_details
+      raise NotImplementedError
+    end
+
   end
 end


### PR DESCRIPTION
Hi @void-in,

Here's my share of the your new Nessus REST API. Mainly here's what I did:
- I moved all the HTTP GET/PUT/POST/DELETE methods as private methods, and then all the Nessus calls are wrappers (so they're all one-liners). There are two main reasons I did it this way: 1) I think it's cleaner; 2) It will be easier for rspec in the future.
- There are some missing methods that Msf::Plugin::Nessus tries to call. Instead of an ugly/scary backtrace, they now should raise NotImplementedError. For example:

```
msf > nessus_report_list
[-] Error while running command nessus_report_list: NotImplementedError
```
- I actually had to fix some broken methods in Msf::Plugin::Nessus, such as create_xindex and nessus_index. Also other bugs.
