### PR TITLE
Green rspec for Nessus REST LoginScanner

### DIFF
--- a/lib/metasploit/framework/login_scanner/nessus.rb
+++ b/lib/metasploit/framework/login_scanner/nessus.rb
@@ -34,9 +34,6 @@ module Metasploit
         #   * :status [Metasploit::Model::Login::Status]
         #   * :proof [String] the HTTP response body
         def get_login_state(username, password)
-          # Prep the data needed for login
-          #protocol  = ssl ? 'https' : 'http'
-          #peer      = "#{host}:#{port}"
           login_uri = "#{uri}"
 
           res = send_request({
@@ -81,6 +78,13 @@ module Metasploit
           end
 
           Result.new(result_opts)
+        end
+
+        def set_sane_defaults
+          super
+          # nessus_reset_login has the same default in TARGETURI, but rspec doesn't check nessus_reset_login
+          # so we have to set the default here, too.
+          self.uri = '/session'
         end
 
       end

--- a/spec/lib/metasploit/framework/login_scanner/nessus_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/nessus_spec.rb
@@ -21,7 +21,9 @@ describe Metasploit::Framework::LoginScanner::Nessus do
     end
 
     let(:successful_auth_response) do
-      Rex::Proto::Http::Response.new(200, 'OK')
+      res = Rex::Proto::Http::Response.new(200, 'OK')
+      res.body = 'token'
+      res
     end
 
     let(:fail_auth_response) do
@@ -63,11 +65,19 @@ describe Metasploit::Framework::LoginScanner::Nessus do
 
     describe '#get_login_state' do
       it 'sends a login request to /session' do
-        expect(http_scanner).to receive(:send_request).with(hash_including('uri'=>'/session'))
+        allow(http_scanner).to receive(:send_request).with(hash_including('uri'=>'/session')).and_return(response)
+        http_scanner.get_login_state(username, good_password)
       end
 
       it 'sends a login request containing the username and password' do
-        expect(http_scanner).to receive(:send_request).with(hash_including('data'=>"username=#{username}&password=#{password}"))
+        expected_hash = {
+          'vars_post' => {
+            "username" => username,
+            "password" => good_password
+          }
+        }
+        allow(http_scanner).to receive(:send_request).with(hash_including(expected_hash)).and_return(response)
+        http_scanner.get_login_state(username, good_password)
       end
 
       context 'when the credential is valid' do


### PR DESCRIPTION
This PR allows the rspec for the Nessus REST LoginScanner module to be green.

rspec log:

```
$ rspec spec/lib/metasploit/framework/login_scanner/nessus_spec.rb 
Metasploit::Framework::LoginScanner::Nessus ................................................

Finished in 0.14837 seconds
48 examples, 0 failures
```
